### PR TITLE
Fix 'Duplicate declaration: Class[Munin] is already declared; cannot redeclare'

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -32,8 +32,6 @@ define munin::plugin (
   $content_config = '',
   $enable = true ) {
 
-  include munin
-
   $ensure = bool2ensure($enable)
 
   if $source {


### PR DESCRIPTION
If "class { 'munin': }" and "munin::plugin { 'something': }" are used in seperate classes, this include will cause an 'Duplicate declaration: Class[Munin] is already declared; cannot redeclare on node XXX'. 

Without throwing any indication (file, linenumber, etc.) what is triggering this.

Puppet makes this a very confusing issue to debug.
